### PR TITLE
add getter methods to generated types

### DIFF
--- a/pkg/template/types.tmpl
+++ b/pkg/template/types.tmpl
@@ -40,8 +40,6 @@ import (
 {{end}}
 
 
-
-
 // XSD ComplexType declarations
 {{range $s := .ExportableComplexTypes }}
   {{ range .GoComments }}
@@ -81,8 +79,6 @@ import (
 
   {{end}}
 {{end}}
-
-
 
 // XSD SimpleType declarations
 {{range .ExportableSimpleTypes }}

--- a/pkg/template/types.tmpl
+++ b/pkg/template/types.tmpl
@@ -9,7 +9,7 @@ import (
     {{- end }}
 )
 
-{{range .ExportableElements }}
+{{range $s := .ExportableElements }}
   // Element
   type {{ .GoName }} struct {
     XMLName xml.Name `xml:"{{.Name}}"`
@@ -26,11 +26,24 @@ import (
     {{- end}}
   }
 
+  {{ range .Elements -}}
+    func (e *{{ $s.GoName }}) Get{{ .GoFieldName}}() {{.GoMemLayout}}{{ .GoTypeName }} {
+    {{if ne .GoMemLayout "" -}}
+      if e == nil {
+      return nil
+      }
+    {{end -}}
+    return e.{{ .GoFieldName}}
+    }
+
+  {{end}}
 {{end}}
 
 
+
+
 // XSD ComplexType declarations
-{{range .ExportableComplexTypes }}
+{{range $s := .ExportableComplexTypes }}
   {{ range .GoComments }}
   // {{ . -}}
   {{end}}
@@ -55,7 +68,21 @@ import (
 
   InnerXml string `xml:",innerxml" json:"-"`
   }
+
+  {{ range .Elements -}}
+    func (e *{{ $s.GoName }}) Get{{ .GoFieldName}}() {{.GoMemLayout}}{{ .GoTypeName }} {
+    {{if ne .GoMemLayout "" -}}
+      if e == nil {
+      return nil
+      }
+    {{end -}}
+    return e.{{ .GoFieldName}}
+    }
+
+  {{end}}
 {{end}}
+
+
 
 // XSD SimpleType declarations
 {{range .ExportableSimpleTypes }}


### PR DESCRIPTION
Adds getter methods to generated types. This serves two purposes:
1. Deeply nested fields can now be gotten with only a final nil check 
```go
 securityInfo := e.GetCorpActnNtfctn().GetCorporateActionGeneralInformation().GetUnderlyingSecurity().GetFinancialInstrumentIdentification()
if securityInfo != nil {}
```
becomes a safe operation (due to baked in nil checks)
2. Interfaces can be written for common parsing operations 
```go
type date interface {
      func GetDate() ISODate
}
func ParseDate(d date) (dates.Date, error) {
	return dates.ParseISO(string(d.GetDate()))
}
```